### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-#vTeam.framework
+# vTeam.framework
   Checkout <br/>
   git clone https://github.com/hailongz/vTeam.git <br/>
   cd vTeam <br/>
   git submodule init <br/>
   git submodule update <br/>
 
-#Installing xcode project templates
+# Installing xcode project templates
   open vTeam.dmg <br/>
   copy vTeam to Templetes <br/>
 
-#初级使用入门
+# 初级使用入门
   http://v.youku.com/v_show/id_XNjkwMzE3MDQw.html <br/>
 
-#中级使用入门
+# 中级使用入门
   http://v.youku.com/v_show/id_XNjkwMzIwMTIw.html <br/>
 
-#高级使用入门
+# 高级使用入门
   http://v.youku.com/v_show/id_XNjkwMzIyODA0.html <br/>


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
